### PR TITLE
Allow throwing handle.

### DIFF
--- a/debug_assert.hpp
+++ b/debug_assert.hpp
@@ -210,8 +210,10 @@ namespace debug_assert
         // this removes on additional function and encourage optimization
         template <class Expr, class Handler, unsigned Level, typename... Args>
         auto do_assert(const Expr& expr, const source_location& loc, const char* expression,
-                       Handler, level<Level>, Args&&... args) noexcept ->
-            typename enable_if<Level <= Handler::level>::type
+                       Handler, level<Level>,
+                       Args&&... args) noexcept(noexcept(Handler::handle(loc, expression,
+                                                                         forward<Args>(args)...)))
+            -> typename enable_if<Level <= Handler::level>::type
         {
             static_assert(Level > 0, "level of an assertion must not be 0");
             if (!expr())
@@ -232,8 +234,10 @@ namespace debug_assert
 
         template <class Expr, class Handler, typename... Args>
         auto do_assert(const Expr& expr, const source_location& loc, const char* expression,
-                       Handler, Args&&... args) noexcept ->
-            typename enable_if<Handler::level != 0>::type
+                       Handler,
+                       Args&&... args) noexcept(noexcept(Handler::handle(loc, expression,
+                                                                         forward<Args>(args)...)))
+            -> typename enable_if<Handler::level != 0>::type
         {
             if (!expr())
             {

--- a/debug_assert.hpp
+++ b/debug_assert.hpp
@@ -284,8 +284,8 @@ namespace debug_assert
 /// This should not be necessary, the regular version is optimized away
 /// completely.
 #define DEBUG_ASSERT(Expr, ...)                                                                    \
-    debug_assert::detail::do_assert([&] { return Expr; }, DEBUG_ASSERT_CUR_SOURCE_LOCATION, #Expr, \
-                                    __VA_ARGS__)
+    debug_assert::detail::do_assert([&]() noexcept { return Expr; },                               \
+                                    DEBUG_ASSERT_CUR_SOURCE_LOCATION, #Expr, __VA_ARGS__)
 
 /// Marks a branch as unreachable.
 ///
@@ -308,8 +308,8 @@ namespace debug_assert
 /// This should not be necessary, the regular version is optimized away
 /// completely.
 #define DEBUG_UNREACHABLE(...)                                                                     \
-    debug_assert::detail::do_assert([&] { return false; }, DEBUG_ASSERT_CUR_SOURCE_LOCATION, "",   \
-                                    __VA_ARGS__)
+    debug_assert::detail::do_assert([&]() noexcept { return false; },                              \
+                                    DEBUG_ASSERT_CUR_SOURCE_LOCATION, "", __VA_ARGS__)
 #else
 #define DEBUG_ASSERT(Expr, ...) DEBUG_ASSERT_ASSUME(Expr)
 

--- a/debug_assert.hpp
+++ b/debug_assert.hpp
@@ -111,10 +111,9 @@ namespace debug_assert
     /// Inherit from it in your module handler.
     /// If the module does not inherit from this class, it is assumed that
     /// the handle does not throw.
-    template <bool B>
     struct allow_exception
     {
-        static const bool allows_exception = B;
+        static const bool throwing_exception_is_allowed = true;
     };
 
     //=== handler ===//
@@ -223,9 +222,10 @@ namespace debug_assert
         };
 
         template <class Handler>
-        struct allows_exception<Handler, typename enable_if<Handler::allows_exception>::type>
+        struct allows_exception<Handler,
+                                typename enable_if<Handler::throwing_exception_is_allowed>::type>
         {
-            static const bool value = true;
+            static const bool value = Handler::throwing_exception_is_allowed;
         };
 
         //=== assert implementation ===//

--- a/example.cpp
+++ b/example.cpp
@@ -6,42 +6,45 @@
 #define MODULE_A_LEVEL 1 // macro to control assertion level
 // usually set by the build system
 
-// tag type that defines a module 
-struct module_a
-: debug_assert::default_handler, // it uses the default handler
-  debug_assert::set_level<MODULE_A_LEVEL> // and this level
-{};
+// tag type that defines a module
+struct module_a : debug_assert::default_handler,          // it uses the default handler
+                  debug_assert::set_level<MODULE_A_LEVEL> // and this level
+{
+};
 
 void module_a_func(void* ptr)
 {
-    DEBUG_ASSERT(ptr, module_a{}); // minimal assertion
+    DEBUG_ASSERT(ptr, module_a{});                                  // minimal assertion
     DEBUG_ASSERT(2 + 2 == 4, module_a{}, debug_assert::level<2>{}); // assertion with level
-    DEBUG_ASSERT(1 == 0, module_a{}, "this should be true"); // assertion with additional parameters, i.e. a message
-    DEBUG_UNREACHABLE(module_a{}); // mark unreachable statements
+    DEBUG_ASSERT(1 == 0, module_a{},
+                 "this should be true"); // assertion with additional parameters, i.e. a message
+    DEBUG_UNREACHABLE(module_a{});       // mark unreachable statements
 }
 
 //=== module B ===//
 #define MODULE_B_LEVEL 2
 
-struct module_b
-: debug_assert::set_level<MODULE_B_LEVEL>// b uses all assertions with level <= 2
+struct module_b : debug_assert::set_level<MODULE_B_LEVEL> // b uses all assertions with level <= 2
 {
     // module b uses a different handler
     // it does not support a message
     // instead you can specify a pointer value
-    static void handle(const debug_assert::source_location& loc, const char* expression, void* ptr = nullptr)
+    static void handle(const debug_assert::source_location& loc, const char* expression,
+                       void* ptr = nullptr) noexcept
     {
-        std::cerr << "Assertion failure '" << loc.file_name << ':' << loc.line_number << ": " << expression;
+        std::cerr << "Assertion failure '" << loc.file_name << ':' << loc.line_number << ": "
+                  << expression;
         if (ptr)
             std::cerr << " - pointer is " << ptr;
         std::cerr << '\n';
     }
 };
 
-void module_b_func(int &value, void* ptr)
+void module_b_func(int& value, void* ptr)
 {
     DEBUG_ASSERT(ptr == &value, module_b{}, ptr); // uses the additional custom parameter
-    DEBUG_ASSERT(ptr == &value, module_b{}, debug_assert::level<2>{}, ptr); // also works with a custom level
+    DEBUG_ASSERT(ptr == &value, module_b{}, debug_assert::level<2>{},
+                 ptr); // also works with a custom level
 }
 
 int main()


### PR DESCRIPTION
Marking `do_assert` as unconditionally `noexcept` prevents the usage of a handler that throws.

A handler that throws is particularly useful in test suites where you need to check that the assert is false for some input. Handling an exception is easier than handling an abort signal.

There is no logic changes if `Handler::handle` is `noexcept`.
 