### PR TITLE
Static_cast of the __LINE__ macro to unsigned type for instances where __LINE__ might be of long type.

### DIFF
--- a/debug_assert.hpp
+++ b/debug_assert.hpp
@@ -101,7 +101,7 @@ namespace debug_assert
 #define DEBUG_ASSERT_CUR_SOURCE_LOCATION                                                           \
     debug_assert::source_location                                                                  \
     {                                                                                              \
-        __FILE__, __LINE__                                                                         \
+        __FILE__, static_cast<unsigned>(__LINE__)                                                  \
     }
 
     //=== level ===//


### PR DESCRIPTION
This is a fix for https://github.com/foonathan/type_safe/issues/51