### PR TITLE
bump version to 1.3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # found in the top-level directory of this distribution.
 
 cmake_minimum_required(VERSION 3.5)
-project(DEBUG_ASSERT)
+project(DEBUG_ASSERT VERSION 1.3.4)
 
 # Determine if debug_assert is built as a subproject (using add_subdirectory)
 # or if it is the master project.
@@ -72,7 +72,7 @@ set(DEBUG_ASSERT_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
 set(CMAKE_SIZEOF_VOID_P "")
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/debug_assert-config-version.cmake
-  VERSION 1.3.1
+  VERSION 1.3.4
   COMPATIBILITY SameMajorVersion
 )
 set(CMAKE_SIZEOF_VOID_P ${DEBUG_ASSERT_CMAKE_SIZEOF_VOID_P})

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ import os
 class DebugAssert(ConanFile):
     name = 'debug_assert'
     url  = 'https://foonathan.github.io/blog/2016/09/16/assertions.html'
-    version = '1.3.1'
+    version = '1.3.4'
     exports = '*.hpp'
     generators = 'cmake'
 


### PR DESCRIPTION
Version 1.3.3 causes weird compile errors, and was tagged long before the latest commit in this repository.

Even though the project appears to be effectively unmaintained, it makes sense to bump the version and make a new tag. Things like the Meson WrapDB don't seem to like directly tracking the HEAD of projects.
